### PR TITLE
More updates.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
 
+jdk:
+  - openjdk8
+  - openjdk11
+  - openjdk-ea
+
 script: "mvn com.coveo:fmt-maven-plugin:check test"
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
  Alfre 
 --------
-[![Build Status](https://travis-ci.org/broadinstitute/alfre.svg?branch=master)](https://travis-ci.org/broadinstitute/alfre)
+[![Build Status](https://travis-ci.com/broadinstitute/alfre.svg?branch=master)](https://travis-ci.com/broadinstitute/alfre)
 [![codecov](https://codecov.io/gh/broadinstitute/alfre/branch/master/graph/badge.svg)](https://codecov.io/gh/broadinstitute/alfre)
 [![Known Vulnerabilities](https://snyk.io/test/github/broadinstitute/alfre/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/broadinstitute/alfre?targetFile=pom.xml)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/b59a009fd812413a949810277aa14972)](https://www.codacy.com/app/kshakir/alfre)

--- a/alfre-v0-cli/pom.xml
+++ b/alfre-v0-cli/pom.xml
@@ -73,7 +73,7 @@
           <showWarnings>true</showWarnings>
           <compilerArgs>
             <arg>-Werror</arg>
-            <arg>-Xlint:all</arg>
+            <arg>-Xlint:all,-options</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -279,4 +279,25 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>java13+</id>
+      <activation>
+        <jdk>[13,)</jdk>
+      </activation>
+      <properties>
+        <!--
+        jacoco does not work with java 13 yet
+        check back in after https://github.com/jacoco/jacoco/issues/828
+        -->
+        <jacoco.skip>true</jacoco.skip>
+        <!--
+        spotbugs does not work on java 13 yet
+        "java.lang.IllegalArgumentException: Unsupported class file major version 57"
+        -->
+        <spotbugs.skip>true</spotbugs.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/alfre-v0-impl-http/pom.xml
+++ b/alfre-v0-impl-http/pom.xml
@@ -56,7 +56,7 @@
           <showWarnings>true</showWarnings>
           <compilerArgs>
             <arg>-Werror</arg>
-            <arg>-Xlint:all</arg>
+            <arg>-Xlint:all,-options</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -216,4 +216,25 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>java13+</id>
+      <activation>
+        <jdk>[13,)</jdk>
+      </activation>
+      <properties>
+        <!--
+        jacoco does not work with java 13 yet
+        check back in after https://github.com/jacoco/jacoco/issues/828
+        -->
+        <jacoco.skip>true</jacoco.skip>
+        <!--
+        spotbugs does not work on java 13 yet
+        "java.lang.IllegalArgumentException: Unsupported class file major version 57"
+        -->
+        <spotbugs.skip>true</spotbugs.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/alfre-v0-impl-http/src/main/java/alfre.v0.impl.http/HttpFileProvider.java
+++ b/alfre-v0-impl-http/src/main/java/alfre.v0.impl.http/HttpFileProvider.java
@@ -13,8 +13,11 @@ import java.net.URI;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.CopyOption;
+import java.nio.file.OpenOption;
 import java.nio.file.attribute.FileTime;
 import java.text.SimpleDateFormat;
+import java.util.Collection;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -57,12 +60,15 @@ public class HttpFileProvider extends UriFileProvider {
   }
 
   @Override
-  public void copy(final URI sourceUri, final URI targetUri) {
+  public void copy(
+      final URI sourceUri, final URI targetUri, final Collection<? extends CopyOption> options) {
     throw new UnsupportedOperationException("copying not supported");
   }
 
   @Override
-  public ReadableByteChannel read(final URI uri, final long offset) throws Exception {
+  public ReadableByteChannel read(
+      final URI uri, final long offset, final Collection<? extends OpenOption> options)
+      throws Exception {
     final HttpGet request = new HttpGet(uri);
     if (0 < offset) {
       request.setHeader(HttpHeaders.RANGE, String.format("bytes=%s-", offset));
@@ -77,7 +83,9 @@ public class HttpFileProvider extends UriFileProvider {
   }
 
   @Override
-  public WritableByteChannel write(final URI uri, final long offset) throws Exception {
+  public WritableByteChannel write(
+      final URI uri, final long offset, final Collection<? extends OpenOption> options)
+      throws Exception {
     if (0 < offset) {
       throw new UnsupportedOperationException("Cannot resume uploads.");
     }

--- a/alfre-v0-impl-s3/pom.xml
+++ b/alfre-v0-impl-s3/pom.xml
@@ -56,7 +56,7 @@
           <showWarnings>true</showWarnings>
           <compilerArgs>
             <arg>-Werror</arg>
-            <arg>-Xlint:all</arg>
+            <arg>-Xlint:all,-options</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -216,4 +216,25 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>java13+</id>
+      <activation>
+        <jdk>[13,)</jdk>
+      </activation>
+      <properties>
+        <!--
+        jacoco does not work with java 13 yet
+        check back in after https://github.com/jacoco/jacoco/issues/828
+        -->
+        <jacoco.skip>true</jacoco.skip>
+        <!--
+        spotbugs does not work on java 13 yet
+        "java.lang.IllegalArgumentException: Unsupported class file major version 57"
+        -->
+        <spotbugs.skip>true</spotbugs.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/alfre-v0-impl-s3/src/main/java/alfre/v0/impl/s3/S3FileProvider.java
+++ b/alfre-v0-impl-s3/src/main/java/alfre/v0/impl/s3/S3FileProvider.java
@@ -9,7 +9,10 @@ import alfre.v0.util.ChannelUtil;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.CopyOption;
+import java.nio.file.OpenOption;
 import java.nio.file.attribute.FileTime;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
 import software.amazon.awssdk.core.ResponseInputStream;
@@ -73,7 +76,11 @@ public class S3FileProvider extends StringFileProvider {
   }
 
   @Override
-  public ReadableByteChannel read(final String bucket, final String key, final long offset) {
+  public ReadableByteChannel read(
+      final String bucket,
+      final String key,
+      final long offset,
+      final Collection<? extends OpenOption> options) {
     final GetObjectRequest request;
     if (offset <= 0) {
       request = GetObjectRequest.builder().bucket(bucket).key(key).build();
@@ -86,7 +93,11 @@ public class S3FileProvider extends StringFileProvider {
   }
 
   @Override
-  public WritableByteChannel write(final String bucket, final String key, final long offset) {
+  public WritableByteChannel write(
+      final String bucket,
+      final String key,
+      final long offset,
+      final Collection<? extends OpenOption> options) {
     if (0 < offset) {
       throw new UnsupportedOperationException("Cannot resume uploads.");
     }
@@ -116,7 +127,8 @@ public class S3FileProvider extends StringFileProvider {
       final String sourceBucket,
       final String sourceKey,
       final String targetBucket,
-      final String targetKey) {
+      final String targetKey,
+      final Collection<? extends CopyOption> options) {
     /*
     In the original SDK these used to be passed as separate values.
     https://github.com/aws/aws-sdk-java/blob/1.11.354/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/CopyObjectRequest.java#L50-L57

--- a/alfre-v0-spi/pom.xml
+++ b/alfre-v0-spi/pom.xml
@@ -60,7 +60,7 @@
           <showWarnings>true</showWarnings>
           <compilerArgs>
             <arg>-Werror</arg>
-            <arg>-Xlint:all</arg>
+            <arg>-Xlint:all,-options</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -220,4 +220,25 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>java13+</id>
+      <activation>
+        <jdk>[13,)</jdk>
+      </activation>
+      <properties>
+        <!--
+        jacoco does not work with java 13 yet
+        check back in after https://github.com/jacoco/jacoco/issues/828
+        -->
+        <jacoco.skip>true</jacoco.skip>
+        <!--
+        spotbugs does not work on java 13 yet
+        "java.lang.IllegalArgumentException: Unsupported class file major version 57"
+        -->
+        <spotbugs.skip>true</spotbugs.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/alfre-v0-spi/src/main/java/alfre/v0/spi/CloudFileProvider.java
+++ b/alfre-v0-spi/src/main/java/alfre/v0/spi/CloudFileProvider.java
@@ -2,6 +2,9 @@ package alfre.v0.spi;
 
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.CopyOption;
+import java.nio.file.OpenOption;
+import java.util.Collection;
 import java.util.Optional;
 
 public interface CloudFileProvider<CloudHostT extends CloudHost> {
@@ -23,14 +26,20 @@ public interface CloudFileProvider<CloudHostT extends CloudHost> {
   }
 
   default void copy(
-      final CloudPath<CloudHostT> sourceCloudPath, final CloudPath<CloudHostT> targetCloudPath)
+      final CloudPath<CloudHostT> sourceCloudPath,
+      final CloudPath<CloudHostT> targetCloudPath,
+      final Collection<? extends CopyOption> options)
       throws Exception {
     throw new UnsupportedOperationException(getClass() + " copying not supported");
   }
 
-  ReadableByteChannel read(CloudPath<CloudHostT> cloudPath, long offset) throws Exception;
+  ReadableByteChannel read(
+      CloudPath<CloudHostT> cloudPath, long offset, final Collection<? extends OpenOption> options)
+      throws Exception;
 
-  WritableByteChannel write(CloudPath<CloudHostT> cloudPath, long offset) throws Exception;
+  WritableByteChannel write(
+      CloudPath<CloudHostT> cloudPath, long offset, final Collection<? extends OpenOption> options)
+      throws Exception;
 
   boolean deleteIfExists(CloudPath<CloudHostT> cloudPath) throws Exception;
 

--- a/alfre-v0-spi/src/main/java/alfre/v0/spi/string/StringFileProvider.java
+++ b/alfre-v0-spi/src/main/java/alfre/v0/spi/string/StringFileProvider.java
@@ -7,6 +7,9 @@ import alfre.v0.spi.CloudPath;
 import alfre.v0.spi.CloudRegularFileAttributes;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.CopyOption;
+import java.nio.file.OpenOption;
+import java.util.Collection;
 import java.util.Optional;
 
 public abstract class StringFileProvider implements CloudFileProvider<StringHost> {
@@ -43,40 +46,60 @@ public abstract class StringFileProvider implements CloudFileProvider<StringHost
         marker);
   }
 
-  public abstract ReadableByteChannel read(String cloudHost, String cloudPath, long offset)
+  public abstract ReadableByteChannel read(
+      String cloudHost,
+      String cloudPath,
+      long offset,
+      final Collection<? extends OpenOption> options)
       throws Exception;
 
   @Override
-  public final ReadableByteChannel read(final CloudPath<StringHost> cloudPath, final long offset)
+  public final ReadableByteChannel read(
+      final CloudPath<StringHost> cloudPath,
+      final long offset,
+      final Collection<? extends OpenOption> options)
       throws Exception {
-    return read(cloudPath.getCloudHost().getHost(), cloudPath.getAbsolutedPathAsString(), offset);
+    return read(
+        cloudPath.getCloudHost().getHost(), cloudPath.getAbsolutedPathAsString(), offset, options);
   }
 
-  public abstract WritableByteChannel write(String cloudHost, String cloudPath, long offset)
+  public abstract WritableByteChannel write(
+      String cloudHost,
+      String cloudPath,
+      long offset,
+      final Collection<? extends OpenOption> options)
       throws Exception;
 
   @Override
-  public final WritableByteChannel write(final CloudPath<StringHost> cloudPath, final long offset)
+  public final WritableByteChannel write(
+      final CloudPath<StringHost> cloudPath,
+      final long offset,
+      final Collection<? extends OpenOption> options)
       throws Exception {
-    return write(cloudPath.getCloudHost().getHost(), cloudPath.getAbsolutedPathAsString(), offset);
+    return write(
+        cloudPath.getCloudHost().getHost(), cloudPath.getAbsolutedPathAsString(), offset, options);
   }
 
   public abstract void copy(
       final String sourceCloudHost,
       final String sourceCloudPath,
       final String targetCloudHost,
-      final String targetCloudPath)
+      final String targetCloudPath,
+      final Collection<? extends CopyOption> options)
       throws Exception;
 
   @Override
   public final void copy(
-      final CloudPath<StringHost> sourceCloudPath, final CloudPath<StringHost> targetCloudPath)
+      final CloudPath<StringHost> sourceCloudPath,
+      final CloudPath<StringHost> targetCloudPath,
+      final Collection<? extends CopyOption> options)
       throws Exception {
     copy(
         sourceCloudPath.getCloudHost().getHost(),
         sourceCloudPath.getAbsolutedPathAsString(),
         targetCloudPath.getCloudHost().getHost(),
-        targetCloudPath.getAbsolutedPathAsString());
+        targetCloudPath.getAbsolutedPathAsString(),
+        options);
   }
 
   public abstract boolean deleteIfExists(String cloudHost, String cloudPath) throws Exception;

--- a/alfre-v0-spi/src/main/java/alfre/v0/spi/uri/UriFileProvider.java
+++ b/alfre-v0-spi/src/main/java/alfre/v0/spi/uri/UriFileProvider.java
@@ -8,6 +8,9 @@ import alfre.v0.spi.CloudRegularFileAttributes;
 import java.net.URI;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.CopyOption;
+import java.nio.file.OpenOption;
+import java.util.Collection;
 import java.util.Optional;
 
 @SuppressWarnings("WeakerAccess")
@@ -44,29 +47,43 @@ public abstract class UriFileProvider implements CloudFileProvider<UriHost> {
     return list(cloudPathPrefix.toUri(), marker);
   }
 
-  public abstract void copy(final URI sourceUri, final URI targetUri) throws Exception;
+  public abstract void copy(
+      final URI sourceUri, final URI targetUri, final Collection<? extends CopyOption> options)
+      throws Exception;
 
   @Override
   public final void copy(
-      final CloudPath<UriHost> sourceCloudPath, final CloudPath<UriHost> targetCloudPath)
+      final CloudPath<UriHost> sourceCloudPath,
+      final CloudPath<UriHost> targetCloudPath,
+      final Collection<? extends CopyOption> options)
       throws Exception {
-    copy(sourceCloudPath.toUri(), targetCloudPath.toUri());
+    copy(sourceCloudPath.toUri(), targetCloudPath.toUri(), options);
   }
 
-  public abstract ReadableByteChannel read(final URI uri, final long offset) throws Exception;
+  public abstract ReadableByteChannel read(
+      final URI uri, final long offset, final Collection<? extends OpenOption> options)
+      throws Exception;
 
   @Override
-  public final ReadableByteChannel read(final CloudPath<UriHost> cloudPath, final long offset)
+  public final ReadableByteChannel read(
+      final CloudPath<UriHost> cloudPath,
+      final long offset,
+      final Collection<? extends OpenOption> options)
       throws Exception {
-    return read(cloudPath.toUri(), offset);
+    return read(cloudPath.toUri(), offset, options);
   }
 
-  public abstract WritableByteChannel write(final URI uri, final long offset) throws Exception;
+  public abstract WritableByteChannel write(
+      final URI uri, final long offset, final Collection<? extends OpenOption> options)
+      throws Exception;
 
   @Override
-  public final WritableByteChannel write(final CloudPath<UriHost> cloudPath, final long offset)
+  public final WritableByteChannel write(
+      final CloudPath<UriHost> cloudPath,
+      final long offset,
+      final Collection<? extends OpenOption> options)
       throws Exception {
-    return write(cloudPath.toUri(), offset);
+    return write(cloudPath.toUri(), offset, options);
   }
 
   public abstract boolean deleteIfExists(final URI uri) throws Exception;

--- a/alfre-v0-test/pom.xml
+++ b/alfre-v0-test/pom.xml
@@ -60,7 +60,7 @@
           <showWarnings>true</showWarnings>
           <compilerArgs>
             <arg>-Werror</arg>
-            <arg>-Xlint:all</arg>
+            <arg>-Xlint:all,-options</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -220,4 +220,25 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>java13+</id>
+      <activation>
+        <jdk>[13,)</jdk>
+      </activation>
+      <properties>
+        <!--
+        jacoco does not work with java 13 yet
+        check back in after https://github.com/jacoco/jacoco/issues/828
+        -->
+        <jacoco.skip>true</jacoco.skip>
+        <!--
+        spotbugs does not work on java 13 yet
+        "java.lang.IllegalArgumentException: Unsupported class file major version 57"
+        -->
+        <spotbugs.skip>true</spotbugs.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/alfre-v0-util/pom.xml
+++ b/alfre-v0-util/pom.xml
@@ -49,7 +49,7 @@
           <showWarnings>true</showWarnings>
           <compilerArgs>
             <arg>-Werror</arg>
-            <arg>-Xlint:all</arg>
+            <arg>-Xlint:all,-options</arg>
           </compilerArgs>
         </configuration>
       </plugin>
@@ -209,4 +209,25 @@
       </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>java13+</id>
+      <activation>
+        <jdk>[13,)</jdk>
+      </activation>
+      <properties>
+        <!--
+        jacoco does not work with java 13 yet
+        check back in after https://github.com/jacoco/jacoco/issues/828
+        -->
+        <jacoco.skip>true</jacoco.skip>
+        <!--
+        spotbugs does not work on java 13 yet
+        "java.lang.IllegalArgumentException: Unsupported class file major version 57"
+        -->
+        <spotbugs.skip>true</spotbugs.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
- Ignore javac linter warnings for options, as bootclasspath option is very different on 8 vs. 11.
- CI test with multiple java versions.
- Disable jacoco and spotbugs on Java 13, for now.
- Pass through open and copy options to the file providers.
- Allow passing in a CloudRetry to the file system provider constructor.
- Switch travis-ci from .org to .com.